### PR TITLE
Specify table for whereInRaw query

### DIFF
--- a/macro.php
+++ b/macro.php
@@ -27,6 +27,9 @@ Builder::macro('deferredPaginate', function ($perPage = null, $columns = ['*'], 
         'values'  => $paginator->getCollection()->map->getRawOriginal($key)->toArray(),
         'boolean' => 'and',
     ];
+    
+    // To avoid any merging of columns we'll specify the table.
+    $this->query->select("{$table}.*");
 
     // Create a new paginator so that we can put our full records in,
     // not the ones that we modified to select only the primary key.


### PR DESCRIPTION
Hey,

Thanks again for this awesome macro :)

This ensures that the column data returned is for the table being paginated through and not any merged in from any joins. For example, if you're using `hasManyThrough`, and both tables have a `uuid` column, the `uuid` column data is overridden by the joined in table's `uuid` column.

Here's an example:

```php
class Account extends Model
{
    public function comments(): HasManyThrough
    {
        return $this->hasManyThrough(Comment::class, Post::class);
    }
}
```

If both `Comment` and `Post` has a `uuid` the column data returned through this macro would return the uuid for the `Post` instead of the anticipated `uuid` of the `Comment`

By specifying the table selects from table.* instead of * it'll make sure we get the correct data back.