### PR TITLE
Remove condition from CI

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Commit linted files
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: "Fix code styling (ci skip)"
+          commit_message: "Fix code styling [ci skip]"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
GHA has build-it "skip ci" support
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
