### PR TITLE
fix not returning results for scout mixin

### DIFF
--- a/src/ScoutMixin.php
+++ b/src/ScoutMixin.php
@@ -11,7 +11,7 @@ class ScoutMixin
     {
         return function ($perPage = null, $pageName = 'page', $page = null) {
             // Just defer to the Scout Builder for DX purposes.
-            $this->paginate($perPage, $pageName, $page);
+            return $this->paginate($perPage, $pageName, $page);
         };
     }
 }

--- a/tests/Integration/ScoutTest.php
+++ b/tests/Integration/ScoutTest.php
@@ -13,8 +13,10 @@ class ScoutTest extends BaseTest
     public function basic_scout_test()
     {
         $queries = $this->withQueriesLogged(function () {
-            UserScout::search('Person')->paginate();
-            UserScout::search('Person')->fastPaginate();
+            $results1 = UserScout::search('Person')->paginate();
+            $results2 = UserScout::search('Person')->fastPaginate();
+
+            $this->assertEquals($results1->count(), $results2->count());
         });
 
         $this->assertEquals(


### PR DESCRIPTION
Atm all `fastPaginate()` searches with Scout return `null`. This PR fixes it.