### PR TITLE
Add alias for simpleFastPaginate 

### DIFF
--- a/src/BuilderMixin.php
+++ b/src/BuilderMixin.php
@@ -7,9 +7,17 @@ namespace Hammerstone\FastPaginate;
 
 class BuilderMixin
 {
+    /**
+     * @deprecated deprecated, use fastSimplePaginate
+     */
     public function simpleFastPaginate()
     {
-        return (new FastPaginate())->simpleFastPaginate();
+        return $this->fastSimplePaginate();
+    }
+
+    public function fastSimplePaginate()
+    {
+        return (new FastPaginate())->fastSimplePaginate();
     }
 
     public function fastPaginate()

--- a/src/FastPaginate.php
+++ b/src/FastPaginate.php
@@ -24,7 +24,7 @@ class FastPaginate
         });
     }
 
-    public function simpleFastPaginate()
+    public function fastSimplePaginate()
     {
         return $this->paginate('simplePaginate', function (array $items, $paginator) {
             return $this->simplePaginator(

--- a/src/RelationMixin.php
+++ b/src/RelationMixin.php
@@ -49,5 +49,4 @@ class RelationMixin
     {
         return $this->fastSimplePaginate();
     }
-
 }

--- a/src/RelationMixin.php
+++ b/src/RelationMixin.php
@@ -26,7 +26,7 @@ class RelationMixin
         };
     }
 
-    public function simpleFastPaginate()
+    public function fastSimplePaginate()
     {
         return function ($perPage = null, $columns = ['*'], $pageName = 'page', $page = null) {
             /** @var \Illuminate\Database\Eloquent\Relations\Relation $this */
@@ -34,11 +34,20 @@ class RelationMixin
                 $this->query->addSelect($this->shouldSelect($columns));
             }
 
-            return tap($this->query->simpleFastPaginate($perPage, $columns, $pageName, $page), function ($paginator) {
+            return tap($this->query->fastSimplePaginate($perPage, $columns, $pageName, $page), function ($paginator) {
                 if ($this instanceof BelongsToMany) {
                     $this->hydratePivotRelation($paginator->items());
                 }
             });
         };
     }
+
+    /**
+     * @deprecated deprecated, use fastSimplePaginate
+     */
+    public function simpleFastPaginate()
+    {
+        return $this->fastSimplePaginate();
+    }
+
 }

--- a/tests/Integration/BuilderTest.php
+++ b/tests/Integration/BuilderTest.php
@@ -372,5 +372,4 @@ class BuilderTest extends BaseTest
         $this->assertTrue($results->hasMorePages());
         $this->assertEquals(1, $results->currentPage());
     }
-
 }

--- a/tests/Integration/BuilderTest.php
+++ b/tests/Integration/BuilderTest.php
@@ -290,7 +290,7 @@ class BuilderTest extends BaseTest
     public function basic_simple_test()
     {
         $queries = $this->withQueriesLogged(function () use (&$results) {
-            $results = User::query()->simpleFastPaginate();
+            $results = User::query()->fastSimplePaginate();
         });
 
         /** @var \Illuminate\Pagination\Paginator $results */
@@ -312,7 +312,7 @@ class BuilderTest extends BaseTest
     public function basic_simple_test_page_two()
     {
         $queries = $this->withQueriesLogged(function () use (&$results) {
-            $results = User::query()->simpleFastPaginate(5, ['*'], 'page', 2);
+            $results = User::query()->fastSimplePaginate(5, ['*'], 'page', 2);
         });
 
         /** @var \Illuminate\Pagination\Paginator $results */
@@ -334,7 +334,7 @@ class BuilderTest extends BaseTest
     public function basic_simple_test_from_relation()
     {
         $queries = $this->withQueriesLogged(function () use (&$results) {
-            $results = User::first()->posts()->simpleFastPaginate();
+            $results = User::first()->posts()->fastSimplePaginate();
         });
 
         /** @var \Illuminate\Pagination\Paginator $results */
@@ -351,4 +351,26 @@ class BuilderTest extends BaseTest
         $this->assertFalse($results->hasMorePages());
         $this->assertEquals(1, $results->currentPage());
     }
+
+    public function alias_for_simple_test()
+    {
+        $queries = $this->withQueriesLogged(function () use (&$results) {
+            $results = User::query()->simpleFastPaginate();
+        });
+
+        /** @var \Illuminate\Pagination\Paginator $results */
+        $this->assertInstanceOf(Paginator::class, $results);
+        $this->assertEquals(15, $results->count());
+        $this->assertEquals('Person 15', $results->last()->name);
+        $this->assertCount(2, $queries);
+
+        $this->assertEquals(
+            'select * from `users` where `users`.`id` in (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) limit 16 offset 0',
+            $queries[1]['query']
+        );
+
+        $this->assertTrue($results->hasMorePages());
+        $this->assertEquals(1, $results->currentPage());
+    }
+
 }


### PR DESCRIPTION
Since I accidently called the method: simpleFastPaginate for the fast simple paginate. I meant to have called it fastSimplePaginate. 

Corrected the method and deprecated the other one