### PR TITLE
Filter out raw orders

### DIFF
--- a/src/FastPaginate.php
+++ b/src/FastPaginate.php
@@ -103,6 +103,7 @@ class FastPaginate
         // have to include certain columns in the inner query.
         $orders = collect($base->orders)
             ->pluck('column')
+            ->filter()
             ->map(function ($column) use ($base) {
                 // Use the grammar to wrap them, so that our `str_contains`
                 // (further down) doesn't return any false positives.

--- a/tests/Integration/Base.php
+++ b/tests/Integration/Base.php
@@ -26,7 +26,9 @@ abstract class Base extends TestCase
     {
         parent::setUp();
 
-        $this->withoutDeprecationHandling();
+        if (method_exists($this, 'withoutDeprecationHandling')) {
+            $this->withoutDeprecationHandling();
+        }
 
         Schema::dropIfExists('users');
         Schema::dropIfExists('posts');

--- a/tests/Integration/BaseTest.php
+++ b/tests/Integration/BaseTest.php
@@ -26,6 +26,8 @@ abstract class BaseTest extends TestCase
     {
         parent::setUp();
 
+        $this->withoutDeprecationHandling();
+
         Schema::dropIfExists('users');
         Schema::dropIfExists('posts');
         Schema::dropIfExists('notifications');


### PR DESCRIPTION
When a developer adds a raw order by expression using `Builder@orderByRaw`, the record created in the query builder's `$orders` property does not contain a field called `column`.

Therefore, when plucking the `column` attribute from the `$orders` properties and mapping to `Grammar@wrap` a null value is passed to the raw order by statements. 

Inside `Grammar@wrap` it calls `stripos()` which raises a deprecation warning as it expects its first parameter to be a string and not a null value.

This PR:

- Adds a `Collectio@filter` call after plucking the `$orders`'s `column` key to avoid null values being mapped into `Grammar@wrap`