### PR TITLE
Add description to fix `composer show --tree`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "hammerstone/fast-paginate",
-    "description": "",
+    "description": "Fast paginate for Laravel",
     "type": "library",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
While running:

```
composer show --tree
```

![CleanShot 2022-12-03 at 23 02 19](https://user-images.githubusercontent.com/1431995/205478802-83f07cb6-6790-4a6d-bc50-efcfd2124a73.png)


It fails if this package (`hammerstonedev/fast-paginate`) is installed, since the `description` key is empty in `composer.json`. See composer source code where `strtok()` fails since description is null instead of string type: https://github.com/composer/composer/blob/main/src/Composer/Command/ShowCommand.php#L1127

I added a very simple description, nothing too fancy!