### PR TITLE
Prevent query when the keys are empty

### DIFF
--- a/src/FastPaginate.php
+++ b/src/FastPaginate.php
@@ -83,6 +83,10 @@ class FastPaginate
             // Get the key values from the records on the current page without mutating them.
             $ids = $paginator->getCollection()->map->getRawOriginal($key)->toArray();
 
+            if (count($ids) <= 0) {
+                return $paginator;
+            }
+
             if (in_array($model->getKeyType(), ['int', 'integer'])) {
                 $this->query->whereIntegerInRaw("$table.$key", $ids);
             } else {

--- a/tests/Integration/BuilderTest.php
+++ b/tests/Integration/BuilderTest.php
@@ -122,6 +122,20 @@ class BuilderTest extends Base
     }
 
     /** @test */
+    public function not_exists_page_is_preserved()
+    {
+        $queries = $this->withQueriesLogged(function () use (&$results) {
+            $results = User::query()->fastPaginate(2, ['*'], 'page', 16);
+        });
+
+        /** @var \Illuminate\Pagination\LengthAwarePaginator $results */
+        $this->assertEquals(0, $results->count());
+        $this->assertArrayNotHasKey(2, $queries);
+
+        $this->assertFalse($results->hasMorePages());
+    }
+
+    /** @test */
     public function custom_table_is_preserved()
     {
         $this->expectException(QueryException::class);

--- a/tests/Integration/BuilderTest.php
+++ b/tests/Integration/BuilderTest.php
@@ -124,15 +124,19 @@ class BuilderTest extends Base
     /** @test */
     public function not_exists_page_is_preserved()
     {
-        $queries = $this->withQueriesLogged(function () use (&$results) {
-            $results = User::query()->fastPaginate(2, ['*'], 'page', 16);
+        $exists = User::query()->fastPaginate();
+
+        $queries = $this->withQueriesLogged(function () use (&$doesnt) {
+            $doesnt = User::query()->fastPaginate(2, ['*'], 'page', 16);
         });
 
-        /** @var \Illuminate\Pagination\LengthAwarePaginator $results */
-        $this->assertEquals(0, $results->count());
+        $this->assertEquals(get_class($exists), get_class($doesnt));
+
+        /** @var \Illuminate\Pagination\LengthAwarePaginator $doesnt */
+        $this->assertEquals(0, $doesnt->count());
         $this->assertArrayNotHasKey(2, $queries);
 
-        $this->assertFalse($results->hasMorePages());
+        $this->assertFalse($doesnt->hasMorePages());
     }
 
     /** @test */


### PR DESCRIPTION
Dear @aarondfrancis ,

I have a query with the fast pagination that do the follow sql:
```sql
select count(*) as aggregate from `users`;
select `users`.`id` from `users` limit 2 offset 30;
select * from `users` where 0 = 1 limit 3 offset 0;
```

I think the last query of fast paginations is redundant because the keys from the second query result is empty.
Expected:
```sql
select count(*) as aggregate from `users`;
select `users`.`id` from `users` limit 2 offset 30;
```

I have created this PR to prevent it.