### PR TITLE
Custom Selects with an additional order by or query constraint ar not working

### DIFF
--- a/src/FastPaginate.php
+++ b/src/FastPaginate.php
@@ -117,10 +117,16 @@ class FastPaginate
             ->pluck('column')
             ->filter()
             ->map(function ($column) use ($base) {
-                // Use the grammar to wrap them, so that our `str_contains`
-                // (further down) doesn't return any false positives.
-                return $base->grammar->wrap($column);
-            });
+                // Not everyone quotes their custom selects, which
+                // is totally reasonable. We'll look for both
+                // quoted and unquoted, as a kindness.
+                // See https://github.com/hammerstonedev/fast-paginate/pull/57
+                return [
+                    $column,
+                    $base->grammar->wrap($column)
+                ];
+            })
+            ->flatten(1);
 
         return collect($base->columns)
             ->filter(function ($column) use ($orders, $base) {

--- a/tests/Integration/BuilderTest.php
+++ b/tests/Integration/BuilderTest.php
@@ -205,6 +205,32 @@ class BuilderTest extends Base
     }
 
     /** @test */
+    public function selects_are_preserved_if_used_in_order_by()
+    {
+        $queries = $this->withQueriesLogged(function () use (&$results) {
+            $results = User::query()->selectRaw('(select 1 as computed_column)')->orderBy('computed_column')->fastPaginate();
+        });
+
+        $this->assertEquals(
+            'select `users`.`id`, computed_column from `users` order by `computed_column` asc limit 15 offset 0',
+            $queries[1]['query']
+        );
+    }
+
+    /** @test */
+    public function selects_are_preserved_if_used_in_where_constraint()
+    {
+        $queries = $this->withQueriesLogged(function () use (&$results) {
+            $results = User::query()->selectRaw('(select 1 as computed_column)')->where('computed_column', 1)->fastPaginate();
+        });
+
+        $this->assertEquals(
+            'select `users`.`id`, computed_column from `users` where `computed_column` = 1 asc limit 15 offset 0',
+            $queries[1]['query']
+        );
+    }
+
+    /** @test */
     public function havings_defer()
     {
         $queries = $this->withQueriesLogged(function () use (&$results) {

--- a/tests/Integration/BuilderTest.php
+++ b/tests/Integration/BuilderTest.php
@@ -212,7 +212,7 @@ class BuilderTest extends Base
         });
 
         $this->assertEquals(
-            'select `users`.`id`, computed_column from `users` order by `computed_column` asc limit 15 offset 0',
+            'select `users`.`id`, (select 1 as computed_column) from `users` order by `computed_column` asc limit 15 offset 0',
             $queries[1]['query']
         );
     }
@@ -225,7 +225,7 @@ class BuilderTest extends Base
         });
 
         $this->assertEquals(
-            'select `users`.`id`, computed_column from `users` where `computed_column` = 1 asc limit 15 offset 0',
+            'select `users`.`id`, (select 1 as computed_column) from `users` where `computed_column` = 1 asc limit 15 offset 0',
             $queries[1]['query']
         );
     }

--- a/tests/Integration/BuilderTest.php
+++ b/tests/Integration/BuilderTest.php
@@ -205,27 +205,14 @@ class BuilderTest extends Base
     }
 
     /** @test */
-    public function selects_are_preserved_if_used_in_order_by()
+    public function unquoted_selects_are_preserved_if_used_in_order_by()
     {
         $queries = $this->withQueriesLogged(function () use (&$results) {
-            $results = User::query()->selectRaw('(select 1 as computed_column)')->orderBy('computed_column')->fastPaginate();
+            $results = User::query()->selectRaw('(select 1) as computed_column')->orderBy('computed_column')->fastPaginate();
         });
 
         $this->assertEquals(
-            'select `users`.`id`, (select 1 as computed_column) from `users` order by `computed_column` asc limit 15 offset 0',
-            $queries[1]['query']
-        );
-    }
-
-    /** @test */
-    public function selects_are_preserved_if_used_in_where_constraint()
-    {
-        $queries = $this->withQueriesLogged(function () use (&$results) {
-            $results = User::query()->selectRaw('(select 1 as computed_column)')->where('computed_column', 1)->fastPaginate();
-        });
-
-        $this->assertEquals(
-            'select `users`.`id`, (select 1 as computed_column) from `users` where `computed_column` = 1 asc limit 15 offset 0',
+            'select `users`.`id`, (select 1) as computed_column from `users` order by `computed_column` asc limit 15 offset 0',
             $queries[1]['query']
         );
     }


### PR DESCRIPTION
Hi Aaron,

thanks for this package! This has speed up our queries tremendously :)

We encountered a little inconvenience with custom selects used in order by or where clauses.

For example, if you have a query llike this:

```php
User::query()
  ->selectRaw('(select 1 as computed_column)')
  ->orderBy('computed_column')
  ->fastPaginate()
```

or that

```php
User::query()
  ->selectRaw('(select 1 as computed_column)')
  ->where('computed_column', 1)
  ->fastPaginate()
```

We get an error that the column doesn't exist. The problem here is, that the "Inner"-query is stripping away all the custom selects.
I added some failing tests in this PR so you can see this in action.

I think its for performance reasons because in most of the cases you only need the ids for the inner query.

What do you think, is there any possibility this gets fixed/added?

King regards
Markus