### PR TITLE
update for laravel 11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ 7.4, 8.0, 8.1, 8.2 ]
-        laravel: [ 8.*, 9.* , 10.*]
+        php: [ 7.4, 8.0, 8.1, 8.2, 8.3 ]
+        laravel: [ 8.*, 9.* , 10.*, 11.*]
         dependency-version: [ prefer-lowest, prefer-stable ]
         include:
+          - laravel: 10.*
+            testbench: 9.*
           - laravel: 10.*
             testbench: 8.*
           - laravel: 8.*

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "illuminate/database": "^8.37|^9.0|^10.0"
+        "illuminate/database": "^8.37|^9.0|^10.0|^11.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6|^7|^8.0",
+        "orchestra/testbench": "^6|^7|^8.0|^9.0",
         "mockery/mockery": "^1.3.3",
         "phpunit/phpunit": ">=8.5.23|^9",
         "laravel/scout": "^9.4"


### PR DESCRIPTION
This PR updates dependencies for Laravel 11 and php 8.3 and contextually the GH Action that runs the tests