### PR TITLE
Fixing Query expressions as orderBy clauses

### DIFF
--- a/src/FastPaginate.php
+++ b/src/FastPaginate.php
@@ -125,6 +125,8 @@ class FastPaginate
                 // is totally reasonable. We'll look for both
                 // quoted and unquoted, as a kindness.
                 // See https://github.com/hammerstonedev/fast-paginate/pull/57
+                $column = $column instanceof Expression ? $column->getValue($base->grammar) : $column;
+
                 return [
                     $column,
                     $base->grammar->wrap($column),

--- a/tests/Integration/BuilderTest.php
+++ b/tests/Integration/BuilderTest.php
@@ -239,7 +239,9 @@ class BuilderTest extends Base
     public function using_expressions_for_order_work()
     {
         $queries = $this->withQueriesLogged(function () use (&$results) {
-            $results = User::query()->selectRaw('(select 1) as computed_column')->orderBy(User::query()->select('name')->orderBy('name')->limit(1)->getQuery())->fastPaginate();
+            $results = User::query()->selectRaw('(select 1) as computed_column')->orderBy(
+                User::query()->select('name')->orderBy('name')->limit(1)->getQuery()
+            )->fastPaginate();
         });
 
         $this->assertEquals(

--- a/tests/Integration/BuilderTest.php
+++ b/tests/Integration/BuilderTest.php
@@ -236,6 +236,19 @@ class BuilderTest extends Base
     }
 
     /** @test */
+    public function using_expressions_for_order_work()
+    {
+        $queries = $this->withQueriesLogged(function () use (&$results) {
+            $results = User::query()->selectRaw('(select 1) as computed_column')->orderBy(User::query()->select('name')->orderBy('name')->limit(1)->getQuery())->fastPaginate();
+        });
+
+        $this->assertEquals(
+            'select `users`.`id` from `users` order by (select `name` from `users` order by `name` asc limit 1) asc limit 15 offset 0',
+            $queries[1]['query']
+        );
+    }
+
+    /** @test */
     public function havings_defer()
     {
         $queries = $this->withQueriesLogged(function () use (&$results) {


### PR DESCRIPTION
Making sure order columns are converted to string.

---

Fixes: #66 