### PR TITLE
Add total parameter to paginate method

### DIFF
--- a/src/FastPaginate.php
+++ b/src/FastPaginate.php
@@ -38,7 +38,7 @@ class FastPaginate
 
     protected function paginate(string $paginationMethod, Closure $paginatorOutput)
     {
-        return function ($perPage = null, $columns = ['*'], $pageName = 'page', $page = null) use (
+        return function ($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $total = null) use (
             $paginationMethod,
             $paginatorOutput
         ) {
@@ -48,7 +48,9 @@ class FastPaginate
             // we are counting on each row of the inner query to return a primary key
             // that we can use. When grouping, that's not always the case.
             if (filled($base->havings) || filled($base->groups) || filled($base->unions)) {
-                return $this->{$paginationMethod}($perPage, $columns, $pageName, $page);
+                return $paginationMethod === 'paginate'
+                ? $this->{$paginationMethod}($perPage, $columns, $pageName, $page, $total)
+                : $this->{$paginationMethod}($perPage, $columns, $pageName, $page);
             }
 
             $model = $this->newModelInstance();
@@ -60,13 +62,17 @@ class FastPaginate
             // fast pagination, we'll just return the normal paginator in that case.
             // https://github.com/aarondfrancis/fast-paginate/issues/39
             if ($perPage === -1) {
-                return $this->{$paginationMethod}($perPage, $columns, $pageName, $page);
+                return $paginationMethod === 'paginate'
+                ? $this->{$paginationMethod}($perPage, $columns, $pageName, $page, $total)
+                : $this->{$paginationMethod}($perPage, $columns, $pageName, $page);
             }
 
             try {
                 $innerSelectColumns = FastPaginate::getInnerSelectColumns($this);
             } catch (QueryIncompatibleWithFastPagination $e) {
-                return $this->{$paginationMethod}($perPage, $columns, $pageName, $page);
+                return $paginationMethod === 'paginate'
+                ? $this->{$paginationMethod}($perPage, $columns, $pageName, $page, $total)
+                : $this->{$paginationMethod}($perPage, $columns, $pageName, $page);
             }
 
             // This is the copy of the query that becomes
@@ -78,8 +84,10 @@ class FastPaginate
                 // We don't need eager loads for this cloned query, they'll
                 // remain on the query that actually gets the records.
                 // (withoutEagerLoads not available on Laravel 8.)
-                ->setEagerLoads([])
-                ->{$paginationMethod}($perPage, ['*'], $pageName, $page);
+                ->setEagerLoads([]);
+            $paginator = $paginationMethod === 'paginate'
+                ? $paginator->{$paginationMethod}($perPage, ['*'], $pageName, $page, $total)
+                : $paginator->{$paginationMethod}($perPage, ['*'], $pageName, $page);
 
             // Get the key values from the records on the current page without mutating them.
             $ids = $paginator->getCollection()->map->getRawOriginal($key)->toArray();

--- a/src/RelationMixin.php
+++ b/src/RelationMixin.php
@@ -13,13 +13,13 @@ class RelationMixin
 {
     public function fastPaginate()
     {
-        return function ($perPage = null, $columns = ['*'], $pageName = 'page', $page = null) {
+        return function ($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $total = null) {
             /** @var \Illuminate\Database\Eloquent\Relations\Relation $this */
             if ($this instanceof HasManyThrough || $this instanceof BelongsToMany) {
                 $this->query->addSelect($this->shouldSelect($columns));
             }
 
-            return tap($this->query->fastPaginate($perPage, $columns, $pageName, $page), function ($paginator) {
+            return tap($this->query->fastPaginate($perPage, $columns, $pageName, $page, $total), function ($paginator) {
                 if ($this instanceof BelongsToMany) {
                     $this->hydratePivotRelation($paginator->items());
                 }

--- a/src/ScoutMixin.php
+++ b/src/ScoutMixin.php
@@ -8,11 +8,11 @@ namespace AaronFrancis\FastPaginate;
 
 class ScoutMixin
 {
-    public function fastPaginate($perPage = null, $pageName = 'page', $page = null)
+    public function fastPaginate($perPage = null, $pageName = 'page', $page = null, $total = null)
     {
-        return function ($perPage = null, $pageName = 'page', $page = null) {
+        return function ($perPage = null, $pageName = 'page', $page = null, $total = null) {
             // Just defer to the Scout Builder for DX purposes.
-            return $this->paginate($perPage, $pageName, $page);
+            return $this->paginate($perPage, $pageName, $page, $total);
         };
     }
 }


### PR DESCRIPTION
Hello, this is a request regarding the issue. https://github.com/aarondfrancis/fast-paginate/issues/74

For records exceeding 10 million, the problem arises where the count query is called every time the page is changed.
In such cases, caching the $total value can reduce queries and improve speed.

Additionally, when used together with [mikebronner/laravel-model-caching](https://github.com/mikebronner/laravel-model-caching), it can provide pagination more easily and faster.

Please consider this request.

Thank you.

Example:
```php
$total = $query->count('id'); // use Cachable; (mikebronner/laravel-model-caching)

return $query->fastPaginate(perPage: $perPage, columns: ['*'], page: $page, total: $total);
```
