### PR TITLE
Fix #73: Add default order by primary key when no order is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 # Changelog
-## Unreleased 
+## Unreleased
+- Add default `ORDER BY` primary key when no order is specified to ensure deterministic pagination results ([#73](https://github.com/aarondfrancis/fast-paginate/issues/73))

--- a/src/FastPaginate.php
+++ b/src/FastPaginate.php
@@ -69,6 +69,14 @@ class FastPaginate
                 return $this->{$paginationMethod}($perPage, $columns, $pageName, $page);
             }
 
+            // If no order is specified, we need to add a default order by
+            // primary key to ensure deterministic results. Without this,
+            // MySQL may return rows in an unpredictable order.
+            // https://github.com/aarondfrancis/fast-paginate/issues/73
+            if (empty($base->orders)) {
+                $this->orderBy("$table.$key");
+            }
+
             // This is the copy of the query that becomes
             // the inner query that selects keys only.
             $paginator = $this->clone()

--- a/tests/Integration/BuilderTest.php
+++ b/tests/Integration/BuilderTest.php
@@ -347,7 +347,7 @@ class BuilderTest extends Base
 
         $this->assertCount(3, $queries);
         $this->assertEquals(
-            'select * from `notifications` where `notifications`.`id` in (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) limit 16 offset 0',
+            'select * from `notifications` where `notifications`.`id` in (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) order by `notifications`.`id` asc limit 16 offset 0',
             $queries[2]['query']
         );
 

--- a/tests/Integration/RelationTest.php
+++ b/tests/Integration/RelationTest.php
@@ -20,7 +20,7 @@ class RelationTest extends Base
         });
 
         $this->assertEquals(
-            'select * from `posts` where `posts`.`user_id` = ? and `posts`.`user_id` is not null and `posts`.`id` in (1) limit 16 offset 0',
+            'select * from `posts` where `posts`.`user_id` = ? and `posts`.`user_id` is not null and `posts`.`id` in (1) order by `posts`.`id` asc limit 16 offset 0',
             $queries[2]['query']
         );
     }


### PR DESCRIPTION
When using fastPaginate without an explicit ORDER BY clause, MySQL may return rows in an unpredictable order, which can cause inconsistent pagination results (e.g., missing the first row).

This fix adds a default ORDER BY on the primary key when no explicit order is specified, ensuring deterministic results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pagination now returns deterministic results by applying default ordering on the primary key when no explicit sort order is specified, ensuring consistent behavior across databases.

* **Tests**
  * Updated test expectations to verify default primary-key ordering in pagination queries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->