### PR TITLE
Laravel 13.x Compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,11 +17,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.2', '8.3', '8.4']
-        laravel: ['10.*', '11.*', '12.*']
+        php: ['8.2', '8.3', '8.4', '8.5']
+        laravel: ['^10.0', '*']
         dependency-version: [prefer-stable]
 
-    name: P${{ matrix.php }} / L${{ matrix.laravel }} / ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} / Laravel ${{ matrix.laravel }}
 
     services:
       mysql:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,11 +17,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.2', '8.3', '8.4', '8.5']
-        laravel: ['10.*', '*']
+        php: [8.2, 8.3, 8.4, 8.5]
+        laravel: ['10.*', '11.*', '12.*', '13.*']
         dependency-version: [prefer-stable]
+        exclude:
+          - laravel: '13.*'
+            php: 8.2
+          - laravel: '10.*'
+            php: 8.5
 
-    name: P${{ matrix.php }} / Laravel ${{ matrix.laravel }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }}
 
     services:
       mysql:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.2', '8.3', '8.4', '8.5']
-        laravel: ['^10.0', '*']
+        laravel: ['10.*', '*']
         dependency-version: [prefer-stable]
 
     name: P${{ matrix.php }} / Laravel ${{ matrix.laravel }}

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/database": "^10.0|^11.0|^12.0"
+        "illuminate/database": ">=10.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "orchestra/testbench": ">=8.0",
         "mockery/mockery": "^1.6",
-        "phpunit/phpunit": "^10.5|^11.0",
-        "laravel/scout": "^10.8|^11.0"
+        "phpunit/phpunit": "^10.5|^11.0|^12.5.12",
+        "laravel/scout": ">=10.8"
     },
     "autoload": {
         "psr-4": {

--- a/src/FastPaginate.php
+++ b/src/FastPaginate.php
@@ -7,6 +7,7 @@
 namespace AaronFrancis\FastPaginate;
 
 use Closure;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\Expression;
 
 class FastPaginate
@@ -57,7 +58,7 @@ class FastPaginate
             $paginationMethod,
             $paginatorOutput
         ) {
-            /** @var \Illuminate\Database\Query\Builder $this */
+            /** @var Builder $this */
             $base = $this->getQuery();
             // Havings, groups, and unions don't work well with this paradigm, because
             // we are counting on each row of the inner query to return a primary key

--- a/src/RelationMixin.php
+++ b/src/RelationMixin.php
@@ -8,13 +8,14 @@ namespace AaronFrancis\FastPaginate;
 
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 class RelationMixin
 {
     public function fastPaginate()
     {
         return function ($perPage = null, $columns = ['*'], $pageName = 'page', $page = null) {
-            /** @var \Illuminate\Database\Eloquent\Relations\Relation $this */
+            /** @var Relation $this */
             if ($this instanceof HasManyThrough || $this instanceof BelongsToMany) {
                 $this->query->addSelect($this->shouldSelect($columns));
             }
@@ -30,7 +31,7 @@ class RelationMixin
     public function simpleFastPaginate()
     {
         return function ($perPage = null, $columns = ['*'], $pageName = 'page', $page = null) {
-            /** @var \Illuminate\Database\Eloquent\Relations\Relation $this */
+            /** @var Relation $this */
             if ($this instanceof HasManyThrough || $this instanceof BelongsToMany) {
                 $this->query->addSelect($this->shouldSelect($columns));
             }

--- a/tests/Integration/BuilderTest.php
+++ b/tests/Integration/BuilderTest.php
@@ -32,7 +32,7 @@ class BuilderTest extends Base
         });
 
         $this->assertInstanceOf(LengthAwarePaginator::class, $results);
-        /** @var \Illuminate\Pagination\LengthAwarePaginator $results */
+        /** @var LengthAwarePaginator $results */
         $this->assertEquals(15, $results->count());
         $this->assertEquals('Person 15', $results->last()->name);
         $this->assertCount(3, $queries);
@@ -54,7 +54,7 @@ class BuilderTest extends Base
             $results = User::query()->fastPaginate(5);
         });
 
-        /** @var \Illuminate\Pagination\LengthAwarePaginator $results */
+        /** @var LengthAwarePaginator $results */
         $this->assertEquals(5, $results->count());
 
         $this->assertEquals(
@@ -74,7 +74,7 @@ class BuilderTest extends Base
             $results = User::query()->fastPaginate(5, ['*'], 'page', 2);
         });
 
-        /** @var \Illuminate\Pagination\LengthAwarePaginator $results */
+        /** @var LengthAwarePaginator $results */
         $this->assertEquals(5, $results->count());
 
         $this->assertEquals(
@@ -95,7 +95,7 @@ class BuilderTest extends Base
             $results = User::query()->fastPaginate(5, ['*'], 'page', 1, 100);
         });
 
-        /** @var \Illuminate\Pagination\LengthAwarePaginator $results */
+        /** @var LengthAwarePaginator $results */
         $this->assertEquals(5, $results->count());
 
         // The $total parameter was added in Laravel 11. On Laravel 10,
@@ -117,7 +117,7 @@ class BuilderTest extends Base
             $results = UserMutatedId::query()->fastPaginate(5);
         });
 
-        /** @var \Illuminate\Pagination\LengthAwarePaginator $results */
+        /** @var LengthAwarePaginator $results */
         $this->assertEquals(5, $results->count());
 
         $this->assertEquals(
@@ -133,7 +133,7 @@ class BuilderTest extends Base
             $results = UserCustomPage::query()->fastPaginate();
         });
 
-        /** @var \Illuminate\Pagination\LengthAwarePaginator $results */
+        /** @var LengthAwarePaginator $results */
         $this->assertEquals(2, $results->count());
 
         $this->assertEquals(
@@ -157,7 +157,7 @@ class BuilderTest extends Base
 
         $this->assertEquals(get_class($exists), get_class($doesnt));
 
-        /** @var \Illuminate\Pagination\LengthAwarePaginator $doesnt */
+        /** @var LengthAwarePaginator $doesnt */
         $this->assertEquals(0, $doesnt->count());
         $this->assertArrayNotHasKey(2, $queries);
 
@@ -325,7 +325,7 @@ class BuilderTest extends Base
             $queries[1]['query']
         );
 
-        /** @var \Illuminate\Pagination\LengthAwarePaginator $results */
+        /** @var LengthAwarePaginator $results */
         $this->assertTrue($results->hasMorePages());
         $this->assertEquals(1, $results->currentPage());
         $this->assertEquals(self::TOTAL_USERS, $results->total());
@@ -399,7 +399,7 @@ class BuilderTest extends Base
             $results = User::query()->simpleFastPaginate();
         });
 
-        /** @var \Illuminate\Pagination\Paginator $results */
+        /** @var Paginator $results */
         $this->assertInstanceOf(Paginator::class, $results);
         $this->assertEquals(15, $results->count());
         $this->assertEquals('Person 15', $results->last()->name);
@@ -421,7 +421,7 @@ class BuilderTest extends Base
             $results = User::query()->simpleFastPaginate(5, ['*'], 'page', 2);
         });
 
-        /** @var \Illuminate\Pagination\Paginator $results */
+        /** @var Paginator $results */
         $this->assertInstanceOf(Paginator::class, $results);
         $this->assertEquals(5, $results->count());
         $this->assertEquals('Person 10', $results->last()->name);
@@ -443,7 +443,7 @@ class BuilderTest extends Base
             $results = User::first()->posts()->simpleFastPaginate();
         });
 
-        /** @var \Illuminate\Pagination\Paginator $results */
+        /** @var Paginator $results */
         $this->assertInstanceOf(Paginator::class, $results);
         $this->assertEquals(1, $results->count());
         $this->assertEquals('Post 1', $results->last()->name);


### PR DESCRIPTION
Update composer.json and GitHub Actions workflow for compatibility an…d versioning

- Adjusted `composer.json` to require `illuminate/database` version `>=10.0` and updated `orchestra/testbench` to `>=8.0`.
- Modified PHPUnit requirement to allow version `^10.5|^11.0|^12.5.12` and set `laravel/scout` to `>=10.8`.
- Updated GitHub Actions workflow to include PHP 8.5 and changed Laravel version specification to `^10.0` and `*` for broader compatibility.